### PR TITLE
Add usage example script

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ z = encode(model, "MKTFFVLLL", tokenizer, cfg.max_len)
 
 The resulting tensor `z` contains the latent representation of the sequence.
 
+For a more complete demonstration, see `examples/usage_example.py` which
+shows encoding and decoding sequences from the command line.
+
 ## Building Documentation
 
 The `vae_module/docs` directory includes a minimal Sphinx configuration. After

--- a/examples/usage_example.py
+++ b/examples/usage_example.py
@@ -1,0 +1,44 @@
+"""Example script demonstrating the vae_module API."""
+
+from torch.utils.data import DataLoader
+
+from vae_module import (
+    Config,
+    Tokenizer,
+    load_vae,
+    encode,
+    decode,
+    encode_batch,
+    SequenceDataset,
+)
+
+
+def main() -> None:
+    """Load the pretrained model and encode/decode example sequences."""
+    cfg = Config(model_path="models/vae_epoch380.pt")
+    tokenizer = Tokenizer.from_esm()
+    model = load_vae(
+        cfg,
+        vocab_size=len(tokenizer.vocab),
+        pad_idx=tokenizer.pad_idx,
+        bos_idx=tokenizer.bos_idx,
+    )
+
+    sequence = "MKTFFVLLL"
+    z = encode(model, sequence, tokenizer, cfg.max_len)
+    reconstructed = decode(model, z, tokenizer, cfg.max_len)
+
+    print("Original sequence:     ", sequence)
+    print("Latent vector shape:   ", tuple(z.shape))
+    print("Reconstructed sequence:", reconstructed)
+
+    # Batch encoding example
+    sequences = [sequence, "ACDEFGHIKLMNPQRSTVWY"]
+    dataset = SequenceDataset(sequences, tokenizer, cfg.max_len)
+    loader = DataLoader(dataset, batch_size=2)
+    Z = encode_batch(model, loader, tokenizer)
+    print("Batch latent tensor shape:", tuple(Z.shape))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- provide `examples/usage_example.py` showing how to encode and decode sequences
- mention the new example script in the README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684f726c94a0832b9f543d4911a29d67