### PR TITLE
Fix usage example DataLoader

### DIFF
--- a/usage_example.py
+++ b/usage_example.py
@@ -10,6 +10,7 @@ from vae_module import (
     decode,
     encode_batch,
     SequenceDataset,
+    pad_collate,
 )
 
 
@@ -35,7 +36,11 @@ def main() -> None:
     # Batch encoding example
     sequences = [sequence, "ACDEFGHIKLMNPQRSTVWY"]
     dataset = SequenceDataset(sequences, tokenizer, cfg.max_len)
-    loader = DataLoader(dataset, batch_size=2)
+    loader = DataLoader(
+        dataset,
+        batch_size=2,
+        collate_fn=lambda batch: pad_collate(batch, tokenizer.pad_idx),
+    )
     Z = encode_batch(model, loader, tokenizer)
     print("Batch latent tensor shape:", tuple(Z.shape))
 

--- a/vae_module/__init__.py
+++ b/vae_module/__init__.py
@@ -5,7 +5,7 @@ from .loader import load_vae
 from .encoder import encode, encode_batch
 from .decoder import decode, decode_batch
 from .classes import SequenceDataset, Tokenizer
-from .utils import sequence_to_tensor, tensor_to_sequence
+from .utils import sequence_to_tensor, tensor_to_sequence, pad_collate
 from .logger import setup_logger
 from .exceptions import (
     VAEError,
@@ -26,6 +26,7 @@ __all__ = [
     "Tokenizer",
     "sequence_to_tensor",
     "tensor_to_sequence",
+    "pad_collate",
     "setup_logger",
     "VAEError",
     "InvalidSequenceError",

--- a/vae_module/utils.py
+++ b/vae_module/utils.py
@@ -19,3 +19,15 @@ def tensor_to_sequence(tensor: torch.Tensor, tokenizer: "Tokenizer") -> str:
     """Convert tensor of token IDs back to string sequence."""
     chars = [tokenizer.get_tok(int(i)) for i in tensor.tolist() if i != tokenizer.pad_idx]
     return "".join(chars)
+
+
+def pad_collate(batch: List[torch.Tensor], pad_idx: int) -> torch.Tensor:
+    """Pad a list of variable length tensors for DataLoader batching."""
+    if not batch:
+        return torch.empty(0, dtype=torch.long)
+    max_len = max(t.size(0) for t in batch)
+    padded = [
+        torch.nn.functional.pad(t, (0, max_len - t.size(0)), value=pad_idx)
+        for t in batch
+    ]
+    return torch.stack(padded)


### PR DESCRIPTION
## Summary
- pad sequences in the DataLoader to allow batching of variable length sequences
- expose `pad_collate` util in package
- use the new collation in `usage_example.py`

## Testing
- `python usage_example.py`

------
https://chatgpt.com/codex/tasks/task_e_684f7cb355f4832b900981caf17a4398