### PR TITLE
Add truncate option to decoder

### DIFF
--- a/usage_example.py
+++ b/usage_example.py
@@ -27,7 +27,7 @@ def main() -> None:
 
     sequence = "MKTFFVLLL"
     z = encode(model, sequence, tokenizer, cfg.max_len)
-    reconstructed = decode(model, z, tokenizer, cfg.max_len)
+    reconstructed = decode(model, z, tokenizer, cfg.max_len, truncate_len=len(sequence))
 
     print("Original sequence:     ", sequence)
     print("Latent vector shape:   ", tuple(z.shape))


### PR DESCRIPTION
## Summary
- support optional truncation length when decoding latent sequences
- allow providing a list of lengths for batch decoding
- update the usage example to clip reconstructed output to the original length

## Testing
- `python usage_example.py` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684fc553d350832ba2422602f02f7bf4