### PR TITLE
Fix PCA script truncation logic

### DIFF
--- a/amino_acid_pca.py
+++ b/amino_acid_pca.py
@@ -39,7 +39,6 @@ def encode_sequences(sequences: List[str], cfg: Config, tokenizer: Tokenizer, mo
     # Truncate sequences longer than the configured maximum length
     truncated = [s[: cfg.max_len] for s in sequences]
     dataset = SequenceDataset(truncated, tokenizer, cfg.max_len)
-    dataset = SequenceDataset(sequences, tokenizer, cfg.max_len)
     loader = DataLoader(
         dataset,
         batch_size=cfg.batch_size,
@@ -60,9 +59,6 @@ def main() -> None:
     )
     if device == "cuda" and torch.cuda.device_count() > 1:
         model = torch.nn.DataParallel(model)
-    cfg = Config(model_path="models/vae_epoch380.pt")
-    tokenizer = Tokenizer.from_esm()
-    model = load_vae(cfg, vocab_size=len(tokenizer.vocab), pad_idx=tokenizer.pad_idx, bos_idx=tokenizer.bos_idx)
 
     labels, sequences = load_sequences("amino acids")
     Z = encode_sequences(sequences, cfg, tokenizer, model).cpu().numpy()


### PR DESCRIPTION
## Summary
- fix dataset truncation logic in `amino_acid_pca.py`
- clean duplicate initialization code

## Testing
- `python -m py_compile amino_acid_pca.py usage_example.py vae_module/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684feb597a50832bb0eea2b5016cf6a6