### PR TITLE
Update README with script instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,25 @@ z = encode(model, "MKTFFVLLL", tokenizer, cfg.max_len)
 
 The resulting tensor `z` contains the latent representation of the sequence.
 
-For a more complete demonstration, see `examples/usage_example.py` which
+For a more complete demonstration, see `usage_example.py` which
 shows encoding and decoding sequences from the command line.
+
+## Example Scripts
+
+Several convenience scripts are included in the repository:
+
+- `usage_example.py` – quick demo that loads the pretrained model and encodes a
+  short sequence.
+- `amino_acid_pca.py` – performs PCA on latent vectors from CSV files inside the
+  `amino acids` directory and visualizes the result.
+- `amino_acid_knn.py` – trains a KNN classifier on the same data and reports the
+  test accuracy.
+
+Run any of these with Python to try them out, for example:
+
+```bash
+python usage_example.py
+```
 
 ## Building Documentation
 


### PR DESCRIPTION
## Summary
- correct `usage_example.py` path in README
- add new section describing example scripts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68510a4dd33c832b810a9ee58d9ce0a3