### PR TITLE
Add encode_long_batch usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,16 @@ The resulting tensor `z` contains the latent representation of the sequence.
 For a more complete demonstration, see `usage_example.py` which
 shows encoding and decoding sequences from the command line.
 
-You can also encode sequences longer than 512 characters using `encode_long`, which returns a stack of latent vectors for overlapping windows.
+You can also encode sequences longer than 512 characters using `encode_long`,
+which returns a stack of latent vectors for overlapping windows. When dealing
+with multiple long sequences, call `encode_long_batch` to obtain a list of
+latent tensor stacks:
+
+```python
+long_sequences = ["MKTFFVLLL" * 100, "ACDEFGHIKLMNPQRSTVWY" * 50]
+embeddings = encode_long_batch(model, long_sequences, tokenizer, cfg.max_len,
+                               overlap=256)
+```
 ## Example Scripts
 
 Several convenience scripts are included in the repository:

--- a/usage/encode_long_batch_example.py
+++ b/usage/encode_long_batch_example.py
@@ -1,0 +1,33 @@
+"""Demonstrate encoding long sequences with encode_long_batch."""
+
+from vae_module import (
+    Config,
+    Tokenizer,
+    load_vae,
+    encode_long_batch,
+)
+
+
+def main() -> None:
+    """Load the pretrained model and encode a list of long sequences."""
+    cfg = Config(model_path="models/vae_epoch380.pt")
+    tokenizer = Tokenizer.from_esm()
+    model = load_vae(
+        cfg,
+        vocab_size=len(tokenizer.vocab),
+        pad_idx=tokenizer.pad_idx,
+        bos_idx=tokenizer.bos_idx,
+    )
+
+    sequences = [
+        "MKTFFVLLL" * 100,
+        "ACDEFGHIKLMNPQRSTVWY" * 50,
+    ]
+    zs = encode_long_batch(model, sequences, tokenizer, cfg.max_len, overlap=256)
+
+    for i, z_stack in enumerate(zs, 1):
+        print(f"Sequence {i} latent stack shape: {tuple(z_stack.shape)}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add example of `encode_long_batch` in README
- include new script `usage/encode_long_batch_example.py` demonstrating how to encode multiple long sequences

## Testing
- `python -m py_compile usage/encode_long_batch_example.py`

------
https://chatgpt.com/codex/tasks/task_e_685d4dab1b5c832ba3258a2fb6ffa458