### PR TITLE
Add encode_batch training example

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,16 @@ The resulting tensor `z` contains the latent representation of the sequence.
 For a more complete demonstration, see `usage_example.py` which
 shows encoding and decoding sequences from the command line.
 
-You can also encode sequences longer than 512 characters using `encode_long`, which returns a stack of latent vectors for overlapping windows.
+You can also encode sequences longer than 512 characters using `encode_long`,
+which returns a stack of latent vectors for overlapping windows. When dealing
+with multiple long sequences, call `encode_long_batch` to obtain a list of
+latent tensor stacks:
+
+```python
+long_sequences = ["MKTFFVLLL" * 100, "ACDEFGHIKLMNPQRSTVWY" * 50]
+embeddings = encode_long_batch(model, long_sequences, tokenizer, cfg.max_len,
+                               overlap=256)
+```
 ## Example Scripts
 
 Several convenience scripts are included in the repository:
@@ -83,13 +92,10 @@ Several convenience scripts are included in the repository:
 - `train_baseline.py` – command-line tool for training a plain VAE on a FASTA
   file. Use this script if you prefer not to run the Jupyter notebooks.
 - `tm_gp_prediction.py` – predicts protein melting temperatures using VAE
-  embeddings with a Gaussian Process regressor. Rows with missing sequences,
-  characters outside the model vocabulary, or sequences longer than the
-  configured maximum length are skipped.
-  embeddings with a Gaussian Process regressor. Any sequence that exceeds the
-  configured maximum length or contains characters outside the model
-  vocabulary is skipped.
-  embeddings with a Gaussian Process regressor.
+  embeddings with a Gaussian Process regressor. Sequences exceeding the maximum
+  length or containing invalid characters are skipped.
+- `encode_long_batch_example.py` – demonstrates encoding several long sequences at once.
+- `encode_batch_training_example.py` – trains a small MLP on embeddings obtained with `encode_batch`.
 
 
 Run any of these with Python to try them out, for example:

--- a/usage/encode_batch_training_example.py
+++ b/usage/encode_batch_training_example.py
@@ -1,0 +1,94 @@
+"""Train MLP on embeddings obtained via encode_batch."""
+
+import numpy as np
+import torch
+import torch.nn as nn
+from torch.utils.data import TensorDataset, DataLoader, random_split
+
+from vae_module import Config, Tokenizer, load_vae
+from amino_acid_pca import load_sequences, encode_sequences
+
+
+def main() -> None:
+    """Encode sequences and train a simple MLP regressor."""
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    cfg = Config(model_path="models/vae_epoch380.pt", device=device)
+    tokenizer = Tokenizer.from_esm()
+    model = load_vae(
+        cfg,
+        vocab_size=len(tokenizer.vocab),
+        pad_idx=tokenizer.pad_idx,
+        bos_idx=tokenizer.bos_idx,
+    )
+    if device == "cuda" and torch.cuda.device_count() > 1:
+        model = torch.nn.DataParallel(model)
+
+    # Load a subset of amino acid sequences
+    _, sequences = load_sequences("amino acids", tokenizer, max_per_class=200)
+    Z = encode_sequences(sequences, cfg, tokenizer, model).cpu().numpy()
+
+    # Example regression targets: sequence lengths normalized to [0,1]
+    y = np.array([len(s) / cfg.max_len for s in sequences], dtype=np.float32)
+
+    X_tensor = torch.from_numpy(Z)
+    y_tensor = torch.from_numpy(y).unsqueeze(1)
+
+    dataset = TensorDataset(X_tensor, y_tensor)
+    train_size = int(len(dataset) * 0.8)
+    val_size = len(dataset) - train_size
+    train_ds, val_ds = random_split(dataset, [train_size, val_size])
+
+    batch_size = 32
+    train_loader = DataLoader(train_ds, batch_size=batch_size, shuffle=True)
+    val_loader = DataLoader(val_ds, batch_size=batch_size)
+
+    class MLPRegressor(nn.Module):
+        def __init__(self, in_dim: int = 256) -> None:
+            super().__init__()
+            self.net = nn.Sequential(
+                nn.Linear(in_dim, 256),
+                nn.ReLU(),
+                nn.Dropout(0.2),
+                nn.Linear(256, 128),
+                nn.ReLU(),
+                nn.Dropout(0.2),
+                nn.Linear(128, 1),
+            )
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            return self.net(x)
+
+    reg = MLPRegressor(in_dim=Z.shape[1]).to(device)
+    criterion = nn.MSELoss()
+    optimizer = torch.optim.Adam(reg.parameters(), lr=1e-3)
+
+    num_epochs = 10
+    for epoch in range(1, num_epochs + 1):
+        reg.train()
+        train_loss = 0.0
+        for xb, yb in train_loader:
+            xb, yb = xb.to(device), yb.to(device)
+            pred = reg(xb)
+            loss = criterion(pred, yb)
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+            train_loss += loss.item() * xb.size(0)
+        train_loss /= len(train_loader.dataset)
+
+        reg.eval()
+        val_loss = 0.0
+        with torch.no_grad():
+            for xb, yb in val_loader:
+                xb, yb = xb.to(device), yb.to(device)
+                pred = reg(xb)
+                val_loss += criterion(pred, yb).item() * xb.size(0)
+        val_loss /= len(val_loader.dataset)
+
+        print(
+            f"Epoch {epoch:>2}/{num_epochs}  Train Loss: {train_loss:.4f}  Val Loss: {val_loss:.4f}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/usage/encode_long_batch_example.py
+++ b/usage/encode_long_batch_example.py
@@ -1,0 +1,33 @@
+"""Demonstrate encoding long sequences with encode_long_batch."""
+
+from vae_module import (
+    Config,
+    Tokenizer,
+    load_vae,
+    encode_long_batch,
+)
+
+
+def main() -> None:
+    """Load the pretrained model and encode a list of long sequences."""
+    cfg = Config(model_path="models/vae_epoch380.pt")
+    tokenizer = Tokenizer.from_esm()
+    model = load_vae(
+        cfg,
+        vocab_size=len(tokenizer.vocab),
+        pad_idx=tokenizer.pad_idx,
+        bos_idx=tokenizer.bos_idx,
+    )
+
+    sequences = [
+        "MKTFFVLLL" * 100,
+        "ACDEFGHIKLMNPQRSTVWY" * 50,
+    ]
+    zs = encode_long_batch(model, sequences, tokenizer, cfg.max_len, overlap=256)
+
+    for i, z_stack in enumerate(zs, 1):
+        print(f"Sequence {i} latent stack shape: {tuple(z_stack.shape)}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- include example script demonstrating training with encode_batch embeddings
- document new script in README and fix repeated lines

## Testing
- `python -m py_compile usage/encode_batch_training_example.py usage/encode_long_batch_example.py`


------
https://chatgpt.com/codex/tasks/task_e_685d4dab1b5c832ba3258a2fb6ffa458