### PR TITLE
Add baseline scoring script

### DIFF
--- a/protein_gym/README.md
+++ b/protein_gym/README.md
@@ -1,0 +1,65 @@
+# ProteinGym Leaderboard Submission
+
+This directory contains helper scripts and documentation for generating
+prediction files that can be submitted to the ProteinGym leaderboard.
+The workflow relies on the pretrained **ESMS VAE** model provided in
+`models/vae_epoch380.pt` and trains a small MLP head on each ProteinGym
+DMS substitution dataset.
+
+## Required Data
+
+1. Download the `DMS_ProteinGym_substitutions` archive from Kaggle or
+the official ProteinGym website.
+2. Place all CSV files into `protein_gym/data/`. Each file should
+   contain a column with the mutated sequence (named either
+   `sequence` or `mutated_sequence`) and a `DMS_score` column.
+
+## Generating Predictions
+
+Run `generate_submission.py` with the folder containing the CSV files
+and an output directory:
+
+```bash
+python protein_gym/generate_submission.py \
+    --data-dir protein_gym/data \
+    --output-dir protein_gym/predictions \
+    --weights models/vae_epoch380.pt
+```
+
+For every CSV file, a new file `<name>_pred.csv` will be written to the
+output directory containing the original sequence and the predicted
+score. These files can be zipped and uploaded to the leaderboard.
+
+## MLP Training Settings
+
+The prediction head is a two-layer MLP trained on the latent
+representations from ESMS VAE. Prior to training, the latent vectors are
+standardised using `StandardScaler`.
+
+```python
+dense_args = {
+    "hidden_layer_sizes": (128, 64),
+    "activation": "relu",
+    "alpha": 9.17e-05,   # L2 regularisation
+    "batch_size": 64,
+    "learning_rate_init": 2.29e-4,
+    "max_iter": 300,
+    "random_state": 42,
+}
+```
+
+The equivalent PyTorch implementation used in `generate_submission.py`
+matches these settings.
+
+## Supervised Models
+
+If you trained additional supervised models for the benchmark, place
+their checkpoints inside `protein_gym/supervised_models/`.
+A short description of each model (architecture, training procedure,
+metrics) can be added to `supervised_models/README.md`.
+
+We also provide a baseline implementation in
+`protein_gym/baselines/ESMSVAE/`. The helper script
+`scripts/scoring_supervised_esmsvae.sh` shows how to download a
+checkpoint, install dependencies and evaluate all supervised assays
+with `scoring.py`.

--- a/protein_gym/baselines/ESMSVAE/README.md
+++ b/protein_gym/baselines/ESMSVAE/README.md
@@ -1,0 +1,19 @@
+# ESMSVAE Baseline
+
+This baseline uses the pretrained ESMS-VAE model and a small MLP regression head to score ProteinGym supervised datasets.
+
+## Usage
+
+```bash
+python baselines/ESMSVAE/scoring.py \
+    --checkpoint models/vae_epoch380.pt \
+    --assay path/to/OTU7A_HUMAN_Tsuboyama_2023_2L2D.csv
+```
+
+The script prints a line of the form:
+
+```
+<assay_name>\tSpearman: 0.8421
+```
+
+Ensure that the dependencies listed in `requirements.txt` are installed before running.

--- a/protein_gym/baselines/ESMSVAE/requirements.txt
+++ b/protein_gym/baselines/ESMSVAE/requirements.txt
@@ -1,0 +1,4 @@
+pandas
+scikit-learn
+torch
+scipy

--- a/protein_gym/baselines/ESMSVAE/scoring.py
+++ b/protein_gym/baselines/ESMSVAE/scoring.py
@@ -1,0 +1,101 @@
+import argparse
+from pathlib import Path
+import pandas as pd
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+from scipy.stats import spearmanr
+from sklearn.preprocessing import StandardScaler
+
+from vae_module import Config, Tokenizer, load_vae, encode_batch, pad_collate
+
+
+class MLPRegressor(torch.nn.Module):
+    def __init__(self, in_dim: int):
+        super().__init__()
+        self.net = torch.nn.Sequential(
+            torch.nn.Linear(in_dim, 128),
+            torch.nn.ReLU(),
+            torch.nn.Dropout(0.2),
+            torch.nn.Linear(128, 64),
+            torch.nn.ReLU(),
+            torch.nn.Dropout(0.2),
+            torch.nn.Linear(64, 1),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.net(x).squeeze(-1)
+
+
+def read_sequences(df: pd.DataFrame):
+    if "sequence" in df.columns:
+        return df["sequence"].astype(str).tolist()
+    if "mutated_sequence" in df.columns:
+        return df["mutated_sequence"].astype(str).tolist()
+    raise ValueError("No sequence column found")
+
+
+def train_regressor(z: torch.Tensor, y: torch.Tensor, device: torch.device):
+    scaler = StandardScaler()
+    z_scaled = torch.tensor(scaler.fit_transform(z.cpu().numpy()), dtype=torch.float32)
+
+    model = MLPRegressor(z_scaled.size(1)).to(device)
+    opt = torch.optim.Adam(model.parameters(), lr=2.29e-4, weight_decay=9.17e-5)
+    loss_fn = torch.nn.MSELoss()
+
+    dataset = TensorDataset(z_scaled.to(device), y.to(device))
+    loader = DataLoader(dataset, batch_size=64, shuffle=True)
+
+    model.train()
+    for _ in range(300):
+        for xb, yb in loader:
+            opt.zero_grad()
+            pred = model(xb)
+            loss = loss_fn(pred, yb)
+            loss.backward()
+            opt.step()
+
+    return model, scaler
+
+
+def score_assay(csv_path: Path, cfg: Config, tokenizer: Tokenizer, vae) -> float:
+    df = pd.read_csv(csv_path)
+    seqs = read_sequences(df)
+    y = torch.tensor(df["DMS_score"].astype(float).values, dtype=torch.float32)
+
+    dataset = TensorDataset(torch.arange(len(seqs)))
+    loader = DataLoader(
+        dataset,
+        batch_size=cfg.batch_size,
+        collate_fn=lambda idx: pad_collate([tokenizer.to_tensor(seqs[i.item()]) for i in idx], tokenizer.pad_idx),
+    )
+    with torch.no_grad():
+        z = encode_batch(vae, loader, tokenizer)
+
+    mlp, scaler = train_regressor(z, y, cfg.device)
+    mlp.eval()
+    z_scaled = torch.tensor(scaler.transform(z.cpu().numpy()), dtype=torch.float32).to(cfg.device)
+    with torch.no_grad():
+        preds = mlp(z_scaled).cpu().numpy()
+
+    rho = spearmanr(preds, y.numpy()).correlation
+    return rho
+
+
+def main():
+    p = argparse.ArgumentParser(description="Score ProteinGym assay with ESMS-VAE")
+    p.add_argument("--checkpoint", required=True, help="Path to ESMS-VAE checkpoint")
+    p.add_argument("--assay", required=True, help="CSV file for one DMS assay")
+    args = p.parse_args()
+
+    cfg = Config(model_path=args.checkpoint, device="cuda" if torch.cuda.is_available() else "cpu")
+    tokenizer = Tokenizer.from_esm()
+    vae = load_vae(cfg, len(tokenizer.vocab), tokenizer.pad_idx, tokenizer.bos_idx)
+    if cfg.device == "cuda" and torch.cuda.device_count() > 1:
+        vae = torch.nn.DataParallel(vae)
+
+    rho = score_assay(Path(args.assay), cfg, tokenizer, vae)
+    print(f"{Path(args.assay).stem}\tSpearman: {rho:.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/protein_gym/generate_submission.py
+++ b/protein_gym/generate_submission.py
@@ -1,0 +1,131 @@
+"""Generate ProteinGym leaderboard submission files using ESMS VAE."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import List
+
+import pandas as pd
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+from scipy.stats import spearmanr
+from sklearn.preprocessing import StandardScaler
+
+from vae_module import (
+    Config,
+    Tokenizer,
+    load_vae,
+    encode_batch,
+    pad_collate,
+)
+
+
+class MLPRegressor(torch.nn.Module):
+    """Simple feed-forward network used for DMS score prediction."""
+
+    def __init__(self, in_dim: int) -> None:
+        super().__init__()
+        self.net = torch.nn.Sequential(
+            torch.nn.Linear(in_dim, 128),
+            torch.nn.ReLU(),
+            torch.nn.Dropout(0.2),
+            torch.nn.Linear(128, 64),
+            torch.nn.ReLU(),
+            torch.nn.Dropout(0.2),
+            torch.nn.Linear(64, 1),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.net(x).squeeze(-1)
+
+
+def read_sequences(df: pd.DataFrame) -> List[str]:
+    if "sequence" in df.columns:
+        return df["sequence"].astype(str).tolist()
+    if "mutated_sequence" in df.columns:
+        return df["mutated_sequence"].astype(str).tolist()
+    raise ValueError("No sequence column found")
+
+
+def train_mlp(z: torch.Tensor, y: torch.Tensor, device: torch.device) -> MLPRegressor:
+    scaler = StandardScaler()
+    z_scaled = torch.tensor(scaler.fit_transform(z.cpu().numpy()), dtype=torch.float32)
+    X_train = z_scaled.to(device)
+    y_train = y.to(device)
+
+    torch.manual_seed(42)
+    model = MLPRegressor(X_train.size(1)).to(device)
+    opt = torch.optim.Adam(
+        model.parameters(), lr=2.29e-4, weight_decay=9.17e-5
+    )
+    loss_fn = torch.nn.MSELoss()
+
+    dataset = TensorDataset(X_train, y_train)
+    loader = DataLoader(dataset, batch_size=64, shuffle=True)
+
+    model.train()
+    for _ in range(300):
+        for xb, yb in loader:
+            opt.zero_grad()
+            pred = model(xb)
+            loss = loss_fn(pred, yb)
+            loss.backward()
+            opt.step()
+    return model, scaler
+
+
+def process_file(path: Path, cfg: Config, tokenizer: Tokenizer, model) -> pd.DataFrame:
+    df = pd.read_csv(path)
+    seqs = read_sequences(df)
+    if "DMS_score" in df.columns:
+        y = torch.tensor(df["DMS_score"].astype(float).values, dtype=torch.float32)
+    else:
+        raise ValueError("DMS_score column is required")
+
+    dataset = TensorDataset(torch.arange(len(seqs)))  # placeholder indices
+    loader = DataLoader(
+        dataset,
+        batch_size=cfg.batch_size,
+        collate_fn=lambda idx: pad_collate([tokenizer.to_tensor(seqs[i.item()]) for i in idx], tokenizer.pad_idx),
+    )
+    with torch.no_grad():
+        z = encode_batch(model, loader, tokenizer)
+
+    mlp, scaler = train_mlp(z, y, device=cfg.device)
+    mlp.eval()
+    z_scaled = torch.tensor(
+        scaler.transform(z.cpu().numpy()), dtype=torch.float32
+    ).to(cfg.device)
+    with torch.no_grad():
+        preds = mlp(z_scaled).cpu().numpy()
+
+    rho = spearmanr(preds, y.numpy()).correlation
+    print(f"{path.name}: Spearman rho={rho:.4f}")
+
+    out = pd.DataFrame({"sequence": seqs, "prediction": preds})
+    return out
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Generate ProteinGym submission")
+    p.add_argument("--data-dir", required=True, help="Directory with ProteinGym CSV files")
+    p.add_argument("--output-dir", required=True, help="Where to store prediction files")
+    p.add_argument("--weights", default="models/vae_epoch380.pt", help="Path to pretrained VAE weights")
+    args = p.parse_args()
+
+    cfg = Config(model_path=args.weights, device="cuda" if torch.cuda.is_available() else "cpu")
+    tokenizer = Tokenizer.from_esm()
+    vae = load_vae(cfg, len(tokenizer.vocab), tokenizer.pad_idx, tokenizer.bos_idx)
+    if cfg.device == "cuda" and torch.cuda.device_count() > 1:
+        vae = torch.nn.DataParallel(vae)
+
+    Path(args.output_dir).mkdir(parents=True, exist_ok=True)
+    for csv_path in sorted(Path(args.data_dir).glob("*.csv")):
+        pred_df = process_file(csv_path, cfg, tokenizer, vae)
+        out_file = Path(args.output_dir) / f"{csv_path.stem}_pred.csv"
+        pred_df.to_csv(out_file, index=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/protein_gym/scripts/scoring_supervised_esmsvae.sh
+++ b/protein_gym/scripts/scoring_supervised_esmsvae.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#SBATCH --job-name=prot_esmsvae
+#SBATCH --gpus=1
+#SBATCH --time=02:00:00
+
+CHECKPOINT_URL="https://your.storage/esmsvae.pt"
+CHECKPOINT_PATH="esmsvae.pt"
+
+wget -O ${CHECKPOINT_PATH} ${CHECKPOINT_URL}
+
+pip install -r protein_gym/baselines/ESMSVAE/requirements.txt
+
+ASSAYS=(
+  OTU7A_HUMAN_Tsuboyama_2023_2L2D
+  SDA_BACSU_Tsuboyama_2023_1PV0
+  # add the remaining assay IDs
+)
+
+for assay in "${ASSAYS[@]}"; do
+  python protein_gym/baselines/ESMSVAE/scoring.py \
+    --checkpoint ${CHECKPOINT_PATH} \
+    --assay data/${assay}.csv
+done

--- a/protein_gym/supervised_models/README.md
+++ b/protein_gym/supervised_models/README.md
@@ -1,0 +1,5 @@
+# Supervised ProteinGym Models
+
+Place checkpoints of any supervised models here. Include a short
+explanation of how each model was trained so the results can be
+reproduced.


### PR DESCRIPTION
## Summary
- implement `proteingym/baselines/ESMSVAE` with scoring script and requirements
- provide Slurm helper script for running the supervised benchmark
- update ProteinGym README with baseline usage instructions

## Testing
- `python -m py_compile protein_gym/generate_submission.py`
- `python -m py_compile proteingym/baselines/ESMSVAE/scoring.py`

------
https://chatgpt.com/codex/tasks/task_e_68611337b79c832b81fc59c0f01d6146