### PR TITLE
Add decoder fine-tuning script

### DIFF
--- a/usage/finetune_decoder.py
+++ b/usage/finetune_decoder.py
@@ -1,0 +1,177 @@
+from typing import List
+import os
+
+import torch
+import torch.optim as optim
+from torch.nn.functional import cross_entropy
+from torch.utils.data import DataLoader, random_split
+from tqdm import tqdm
+
+from vae_module import (
+    Config,
+    Tokenizer,
+    load_vae,
+    SequenceDataset,
+    pad_collate,
+    decode_batch,
+    sequence_to_tensor,
+)
+
+# ---- Configuration ----
+
+# Update these paths and settings as needed before running the script.
+DATA_PATH = "data/train_sequences.fasta"
+CHECKPOINT_PATH = "models/vae_epoch380.pt"
+EPOCHS = 10
+LR = 1e-4
+BATCH_SIZE = 64
+NOISE_PROB = 0.1
+DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
+OUTPUT_DIR = "finetuned"
+MAX_LEN = 512
+
+
+def read_fasta(path: str) -> List[str]:
+    sequences: List[str] = []
+    with open(path) as fh:
+        seq = ""
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            if line.startswith(">"):
+                if seq:
+                    sequences.append(seq)
+                    seq = ""
+            else:
+                seq += line
+        if seq:
+            sequences.append(seq)
+    return sequences
+
+
+def add_noise(tokens: torch.Tensor, prob: float, vocab_size: int, pad_idx: int) -> torch.Tensor:
+    if prob <= 0.0:
+        return tokens
+    noise_mask = (torch.rand(tokens.size(), device=tokens.device) < prob) & (tokens != pad_idx)
+    random_tokens = torch.randint(0, vocab_size, tokens.size(), device=tokens.device)
+    out = tokens.clone()
+    out[noise_mask] = random_tokens[noise_mask]
+    return out
+
+
+def forward_noisy(model, x, mask, noise_prob: float, vocab_size: int):
+    with torch.no_grad():
+        h_enc, enc_mask = model.encoder(x)
+    pooled = (h_enc * enc_mask.unsqueeze(-1)).sum(1) / enc_mask.sum(1, True)
+    mu = model.to_mu(pooled)
+    logvar = model.to_logvar(pooled)
+    z = mu + torch.randn_like(mu) * torch.exp(0.5 * logvar)
+
+    B, L = x.size()
+    dec_in = torch.full((B, L), model.bos_token, device=x.device, dtype=torch.long)
+    dec_in[:, 1:] = x[:, :-1]
+    dec_in = add_noise(dec_in, noise_prob, vocab_size, model.pad_token)
+
+    emb = model.dec_emb(dec_in) + model.dec_pos[:, :L, :]
+    z_emb = model.latent2emb(z).unsqueeze(1).expand(-1, L, -1)
+    emb = emb + z_emb
+
+    tgt_mask = torch.triu(torch.full((L, L), float("-inf"), device=x.device), diagonal=1)
+    h_dec = model.decoder(
+        tgt=emb,
+        memory=h_enc,
+        tgt_mask=tgt_mask,
+        tgt_key_padding_mask=~mask,
+        memory_key_padding_mask=~enc_mask,
+    )
+    logits = model.out(h_dec)
+    return logits, mu, logvar
+
+
+def evaluate(model, loader, tokenizer, max_len: int) -> float:
+    model.eval()
+    device = next(model.parameters()).device
+    correct = 0
+    total = 0
+    with torch.no_grad():
+        for x in loader:
+            x = x.to(device)
+            mask = x != tokenizer.pad_idx
+            h_enc, enc_mask = model.encoder(x)
+            pooled = (h_enc * enc_mask.unsqueeze(-1)).sum(1) / enc_mask.sum(1, True)
+            mu = model.to_mu(pooled)
+            z = mu
+            sequences = decode_batch(
+                model,
+                z,
+                tokenizer,
+                max_len,
+                truncate_lens=mask.sum(1).tolist(),
+            )
+            for seq_pred, xt, m in zip(sequences, x, mask):
+                pred_ids = sequence_to_tensor(seq_pred, tokenizer, max_len)
+                L = int(m.sum().item())
+                correct += (pred_ids[:L].to(device) == xt[:L]).sum().item()
+                total += L
+    return correct / total * 100 if total > 0 else 0.0
+
+
+def main() -> None:
+    tokenizer = Tokenizer.from_esm()
+    cfg = Config(model_path=CHECKPOINT_PATH, device=DEVICE, max_len=MAX_LEN)
+    model = load_vae(
+        cfg,
+        vocab_size=len(tokenizer.vocab),
+        pad_idx=tokenizer.pad_idx,
+        bos_idx=tokenizer.bos_idx,
+    )
+
+    for p in model.encoder.parameters():
+        p.requires_grad = False
+
+    dataset = SequenceDataset(read_fasta(DATA_PATH), tokenizer, MAX_LEN)
+    train_size = int(len(dataset) * 0.9)
+    val_size = len(dataset) - train_size
+    train_ds, val_ds = random_split(dataset, [train_size, val_size])
+    train_loader = DataLoader(
+        train_ds,
+        batch_size=BATCH_SIZE,
+        shuffle=True,
+        collate_fn=lambda b: pad_collate(b, tokenizer.pad_idx),
+    )
+    val_loader = DataLoader(
+        val_ds,
+        batch_size=BATCH_SIZE,
+        collate_fn=lambda b: pad_collate(b, tokenizer.pad_idx),
+    )
+
+    optimizer = optim.Adam(filter(lambda p: p.requires_grad, model.parameters()), lr=LR)
+    device = torch.device(DEVICE)
+
+    os.makedirs(OUTPUT_DIR, exist_ok=True)
+
+    for epoch in range(1, EPOCHS + 1):
+        model.train()
+        total_loss = 0.0
+        for x in tqdm(train_loader, desc=f"Epoch {epoch}"):
+            x = x.to(device)
+            mask = x != tokenizer.pad_idx
+            logits, mu, logvar = forward_noisy(model, x, mask, NOISE_PROB, len(tokenizer.vocab))
+            ce = cross_entropy(logits.view(-1, logits.size(-1)), x.view(-1), ignore_index=tokenizer.pad_idx)
+            kl = -0.5 * torch.mean(1 + logvar - mu.pow(2) - logvar.exp())
+            loss = ce + kl
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+            total_loss += loss.item()
+        avg_loss = total_loss / len(train_loader)
+        acc = evaluate(model, val_loader, tokenizer, MAX_LEN)
+        print(f"Epoch {epoch}: loss={avg_loss:.4f} val_acc={acc:.2f}%")
+        output_path = f"{OUTPUT_DIR}/decoder_ft_epoch{epoch}.pt"
+        torch.save({"model_sd": model.state_dict()}, output_path)
+        print(f"Saved checkpoint to {output_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `finetune_decoder.py` for tuning VAE decoder parameters
- support noisy teacher forcing with adjustable probability
- evaluate reconstruction without teacher forcing
- checkpoint after each epoch
- refactor script to avoid argparse

## Testing
- `python -m py_compile usage/finetune_decoder.py`


------
https://chatgpt.com/codex/tasks/task_e_688b763043f4832ba130e4cf74fa0099